### PR TITLE
op: fix: ModuleNotFoundErrors during deployment and sample data loading (Telco churn data)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ xgboost
 psutil
 streamlit-flow-component
 ipython
+h2o >= 3.46.0.9
+mlflow >= 3.8.1


### PR DESCRIPTION
Thanks for your exciting developments!
During deployment i had a small issue with a missing dependency and would hereby suggest a small and straightforward fix:

ModuleNotFoundError: No module named 'IPython'
The error was displayed in the Terminal as well as in the app in the browser which made its usage impossible
Traceback:
```
File "~/ai-data-science-team/apps/ai-pipeline-studio-app/app.py", line 33, in <module>
    from ai_data_science_team.agents.data_loader_tools_agent import DataLoaderToolsAgent
File "~/ai-data-science-team/ai_data_science_team/__init__.py", line 1, in <module>
    from ai_data_science_team.agents import (
File "~/ai-data-science-team/ai_data_science_team/agents/__init__.py", line 1, in <module>
    from ai_data_science_team.agents.data_cleaning_agent import make_data_cleaning_agent, DataCleaningAgent
File "~/ai-data-science-team/ai_data_science_team/agents/data_cleaning_agent.py", line 22, in <module>
    from IPython.display import Markdown
```

# Solution
pip install ipython
(or adding it to requirements.txt directly)
my ipython version was 8.38.0, not sure if you want to pin it (>=8.38.0)...
The app now starts smoothly and also there are no further errors in the terminal

# Installation and usage steps
pip install -e .
streamlit run apps/ai-pipeline-studio-app/app.py

# My system
conda create -n ds-team python==3.10 -y
conda activate ds-team
python --version # Python 3.10.0
cat /etc/os-release
```
NAME="openSUSE Leap"
VERSION="15.6"
ID="opensuse-leap"
```
